### PR TITLE
GCP の Cloud Run へのデプロイ設定の追加

### DIFF
--- a/Api/PersuadeMate.Api.http
+++ b/Api/PersuadeMate.Api.http
@@ -1,4 +1,4 @@
-@PersuadeMate.Api_HostAddress = http://localhost:5157
+@PersuadeMate.Api_HostAddress = http://localhost:8080
 
 GET {{PersuadeMate.Api_HostAddress}}/weatherforecast/
 Accept: application/json

--- a/Api/Properties/launchSettings.json
+++ b/Api/Properties/launchSettings.json
@@ -14,7 +14,7 @@
       "dotnetRunMessages": true,
       "launchBrowser": true,
       "launchUrl": "swagger",
-      "applicationUrl": "http://localhost:5157",
+      "applicationUrl": "http://localhost:8080",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
@@ -24,7 +24,7 @@
       "dotnetRunMessages": true,
       "launchBrowser": true,
       "launchUrl": "swagger",
-      "applicationUrl": "https://localhost:7114;http://localhost:5157",
+      "applicationUrl": "https://localhost:7114;http://localhost:8080",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build-env
+WORKDIR /App
+COPY . ./
+RUN dotnet restore
+RUN dotnet publish -c Release -o out
+
+FROM mcr.microsoft.com/dotnet/aspnet:8.0
+WORKDIR /App
+COPY --from=build-env /App/out .
+ENTRYPOINT ["dotnet", "PersuadeMate.Api.dll"]

--- a/README.md
+++ b/README.md
@@ -23,5 +23,5 @@ If you want to see all tasks, execute `just run tasks`.
 ## endpoint for development
 
 - https://localhost:7114/
-- http://localhost:5157
+- http://localhost:8080
 


### PR DESCRIPTION
ポート番号 5157 だと GCP 側でうまくいかなかったので 8080 でやらせてくださいm_(_ _)m
main ブランチに push されると GCP 側でデプロイが走るように後ほど設定しておきます。